### PR TITLE
Netlify integrations

### DIFF
--- a/netlify/push-to-netlify.yml
+++ b/netlify/push-to-netlify.yml
@@ -1,0 +1,20 @@
+name: Build on push	
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - ".github/**"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        env:
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        run: |
+          yarn
+          yarn build
+          npx netlify-cli deploy --dir=public --prod


### PR DESCRIPTION
Action to deploy to Netlify with access tokens. I've tried it on another project and it worked. Reason to do this: save costs of "builds" in netlify