### PR TITLE
feat(utils): add lint pr workflow

### DIFF
--- a/utils/lint-pr.yml
+++ b/utils/lint-pr.yml
@@ -1,0 +1,15 @@
+name: "Lint PR"
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v1.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There's a [known issue](https://github.com/amannn/action-semantic-pull-request/issues/5#issuecomment-586856680) : when the check fails and you rename the PR title to fix it, it doesn't make the failed check to re-run, instead adds another one but the old one keeps as failed.

While this is not fixed (we could contribute and help them fix it), there are a couple of workarounds:
- Re-run jobs
- The PR lint action readme suggests to [send an empty commit](https://github.com/seferov/pr-lint-action#known-issues)

I personally prefer just re-running it but since we squash it doesn't really matter, so both options seem fine.